### PR TITLE
Prevent api hub restart

### DIFF
--- a/psknode/bin/scripts/pskApiHubLauncher.js
+++ b/psknode/bin/scripts/pskApiHubLauncher.js
@@ -2,7 +2,9 @@ const TAG = "API-HUB";
 
 let path = require("path");
 
-require("../../core/utils/pingpongFork").enableLifeLine();
+require("../../core/utils/pingpongFork").enableLifeLine({
+    handleExceptionEvents: ["SIGINT", "SIGUSR1", "SIGUSR2", "SIGTERM", "SIGHUP"]
+});
 require(path.join(__dirname, '../../bundles/pskWebServer.js'));
 
 path = require("swarmutils").path;
@@ -40,5 +42,23 @@ function startServer() {
         console.log(`\n[${TAG}] listening on port :${listeningPort} and ready to receive requests.\n`);
     });
 }
+
+// If the apihub port is already in use, exit with exit code 2
+// so that the service launcher will restart the process.
+// For other kind of exception use exit code 1 so that the
+// service launcher won't restart the process
+process.on('uncaughtException', (e) => {
+    // Handle `throw null` && `throw undefined`
+    if (typeof e !== 'object' || !e) {
+        e = new Error(e);
+    }
+
+    let exitCode = 1;
+    if (e.code === 'EADDRINUSE') {
+        exitCode = 2;
+    }
+    console.log(`Unhandled exception:`, e);
+    process.exit(exitCode);
+})
 
 startServer();

--- a/psknode/bin/scripts/serviceLauncher.js
+++ b/psknode/bin/scripts/serviceLauncher.js
@@ -5,7 +5,11 @@ const defaultConfig = {
     services: ["psk_api_hub"],
     maxTimeout: 10 * 60 * 1000, // 10 minutes
     psk_api_hub:{
-        module: "pskApiHubLauncher.js"
+        module: "pskApiHubLauncher.js",
+        restartPolicy: {
+            onError: true, // on spawn error
+            onExit: false
+        }
     },
     domainLauncher:{
         module: "../../core/launcher.js",
@@ -43,7 +47,14 @@ const pingFork = require("../../core/utils/pingpongFork").fork;
 const shouldRestart = true;
 const forkedProcesses = {};
 
-function startProcess(filePath,  args, options) {
+function startProcess(filePath, processOptions) {
+    const args = processOptions.args;
+    const options = processOptions.options
+    const restartPolicy = processOptions.restartPolicy || {
+        onError: shouldRestart,
+        onExit: shouldRestart
+    }
+
     console.log(`[${TAG}] Starting a new process using <${filePath}>`);
     forkedProcesses[filePath] = pingFork(filePath, args, options);
 
@@ -54,31 +65,23 @@ function startProcess(filePath,  args, options) {
         console.log(`Process will restart in ${timeout} ms ...`);
         setTimeout(()=>{
             restartDelays[filePath] = (timeout * 2) % max_timeout;
-            startProcess(filePath);
+            startProcess(filePath, processOptions);
         }, timeout);
     }
 
     function errorHandler(filePath) {
         return function (error) {
             console.log(`\x1b[31mException caught on spawning file ${filePath} `, error ? error : "", "\x1b[0m"); //last string is to reset terminal colours
-            if (shouldRestart) {
+            if (restartPolicy.onError) {
                 restartWithDelay(filePath);
             }
         }
     }
 
     function exitHandler(filePath) {
-        return function (code) {
-            const isApiLauncherService = filePath.indexOf('pskApiHubLauncher') !== -1;
-            let shouldRestartProcess = shouldRestart;
-
-            // The ApiHub service should restart only if exit code == 2 (port is already in use)
-            if (isApiLauncherService && code !== 2) {
-                shouldRestartProcess = false;
-            }
-
+        return function () {
             console.log(`\x1b[33mExit caught on spawned file ${filePath}`, "\x1b[0m"); //last string is to reset terminal colours
-            if (shouldRestartProcess) {
+            if (restartPolicy.onExit) {
                 restartWithDelay(filePath);
             }
         }
@@ -91,5 +94,5 @@ function startProcess(filePath,  args, options) {
 for(let i=0; i<config.services.length; i++){
     let serviceName = config.services[i];
     let serviceConfig = config[serviceName];
-    startProcess(path.join(__dirname, serviceConfig.module));
+    startProcess(path.join(__dirname, serviceConfig.module), serviceConfig);
 }

--- a/psknode/core/utils/pingpongFork.js
+++ b/psknode/core/utils/pingpongFork.js
@@ -32,7 +32,11 @@ module.exports.fork = function pingPongFork(modulePath, args, options){
     return child;
 };
 
-module.exports.enableLifeLine = function(timeout){
+module.exports.enableLifeLine = function(timeout, options) {
+    if (typeof timeout === 'object' && typeof options === 'undefined') {
+        options = timeout;
+        timeout = options.timeout;
+    }
 
     if(typeof process.send === "undefined"){
         console.log("\"process.send\" not found. LifeLine mechanism disabled!");
@@ -67,7 +71,7 @@ module.exports.enableLifeLine = function(timeout){
         }, 0);
     }
 
-    const exceptionEvents = ["SIGINT", "SIGUSR1", "SIGUSR2", "uncaughtException", "SIGTERM", "SIGHUP"];
+    const exceptionEvents = options.handleExceptionEvents || ["SIGINT", "SIGUSR1", "SIGUSR2", "uncaughtException", "SIGTERM", "SIGHUP"];
     let killingSignal = false;
     for(let i=0; i<exceptionEvents.length; i++){
         process.on(exceptionEvents[i], (event, code)=>{


### PR DESCRIPTION
I've changed the `serviceLauncher` script to prevent restarting the apihub when it exits with an error, this implies some changes to `pskApiHubLauncher`:
- retry restarting the server if the port is in use
- exit with code 1 for any other type of exceptions
